### PR TITLE
[RM-55552] Add URL props back to required to avoid undefined

### DIFF
--- a/schemas/pagination-result.schema.yaml
+++ b/schemas/pagination-result.schema.yaml
@@ -33,7 +33,9 @@ properties:
 required:
   - results
   - current_page_num
+  - next_page_url
   - page_first_item_num
   - page_last_item_num
+  - previous_page_url
   - total_item_count
   - total_page_count


### PR DESCRIPTION
Add URL props back to required list to avoid undefined types when using [pagination](https://github.com/elationemr/admin-toolbox/blob/main/frontend/src/common/utils/ApiResponse.types.ts#L1) with generated morval code.