### PR TITLE
Set the results property to "true" in the paginated results schema

### DIFF
--- a/schemas/pagination-result.schema.yaml
+++ b/schemas/pagination-result.schema.yaml
@@ -3,6 +3,11 @@ $id: “urn:elation:schemas:pagination-result”
 title: PaginationResult
 type: object
 properties:
+  # Functionally, PaginatedResult should be a generic PaginatedResult<T> where results is of 
+  # type T[]. But json-schema doesn't support this out of the box, and getting tools to 
+  # understand that is even harder. It's expected that any usage of this schema will be 
+  # via extension (using the allOf keyword), and overriding the results property. 
+  # true effectively acts as an any, which extenders can further constrain while keeping validation correct.
   results: true
   current_page_num:
     description: The current page number based on the given limit and offset.

--- a/schemas/pagination-result.schema.yaml
+++ b/schemas/pagination-result.schema.yaml
@@ -3,8 +3,7 @@ $id: “urn:elation:schemas:pagination-result”
 title: PaginationResult
 type: object
 properties:
-  results:
-    type: array
+  results: true
   current_page_num:
     description: The current page number based on the given limit and offset.
     type: integer

--- a/schemas/pagination-result.schema.yaml
+++ b/schemas/pagination-result.schema.yaml
@@ -4,7 +4,9 @@ title: PaginationResult
 type: object
 properties:
   results:
-    type: object
+    type:
+      - object
+      - array
   current_page_num:
     description: The current page number based on the given limit and offset.
     type: integer

--- a/schemas/pagination-result.schema.yaml
+++ b/schemas/pagination-result.schema.yaml
@@ -4,9 +4,7 @@ title: PaginationResult
 type: object
 properties:
   results:
-    type:
-      - object
-      - array
+    type: array
   current_page_num:
     description: The current page number based on the given limit and offset.
     type: integer


### PR DESCRIPTION
Fixes the pagination "results" type to be an array or an object so that when we do openapi schema validation, we don't recieve errors for list results